### PR TITLE
Fix reboot issue

### DIFF
--- a/mcagents/erase_node.ddl
+++ b/mcagents/erase_node.ddl
@@ -1,4 +1,4 @@
-metadata    :name        => "Erase node bootloader",
+metadata    :name        => "Erase node bootloader and reboot it",
             :description => "Erase node bootloader and reboot it.",
             :author      => "Andrey Danin",
             :license     => "MIT",

--- a/mcagents/erase_node.rb
+++ b/mcagents/erase_node.rb
@@ -79,7 +79,7 @@ module MCollective
       end
 
       def reboot
-        cmd = "/bin/sleep 5; /sbin/shutdown -r now"
+        cmd = "/bin/sleep 5; /sbin/reboot --force"
         pid = fork { system(cmd) }
         Process.detach(pid)
       end
@@ -97,8 +97,10 @@ module MCollective
         fd.seek(offset)
         ret = fd.syswrite("\000"*length)
         fd.close
+        system('/bin/sync')
       end
 
+      # Prevent discover by agent while node rebooting.
       def prevent_discover
         FileUtils.touch '/var/run/nodiscover'
       end

--- a/mcagents/net_probe.ddl
+++ b/mcagents/net_probe.ddl
@@ -4,7 +4,7 @@ metadata    :name        => "Network Probe Agent",
             :license     => "MIT",
             :version     => "0.1",
             :url         => "http://mirantis.com",
-            :timeout     => 300
+            :timeout     => 40
 
 action "start_frame_listeners", :description => "Starts catching packets on interfaces" do
     display :always


### PR DESCRIPTION
Now 'erase_node' agent reboot node instantly. Also timeout for net_probe agent decreased.
Tested by hands.
