### PR TITLE
[mcagent] Add an option --ignorecache to puppet-agent.

### DIFF
--- a/mcagents/puppetd.rb
+++ b/mcagents/puppetd.rb
@@ -157,7 +157,7 @@ module MCollective
       end
 
       def runonce_background
-        cmd = [@puppetd, "--onetime", "--debug", "--logdest", 'syslog']
+        cmd = [@puppetd, "--onetime", "--ignorecache", "--debug", "--logdest", 'syslog']
 
         unless request[:forcerun]
           if @splaytime && @splaytime > 0


### PR DESCRIPTION
Tested by hands.
