### PR TITLE
Add backtrace information to log and stdout. Update console help behavior.

### DIFF
--- a/bin/astute
+++ b/bin/astute
@@ -18,9 +18,11 @@ require 'optparse'
 require 'yaml'
 begin
   require 'astute'
+  require 'astute/version'
 rescue LoadError
   require 'rubygems'
   require 'astute'
+  require 'astute/version'
 end
 
 class ConsoleReporter
@@ -41,7 +43,9 @@ optparse = OptionParser.new do |o|
     opts[:filename] = f
   end
 
-  o.on("-h") { puts o; exit }
+  o.on_tail("-h", "--help", "Show this message") { puts o; exit }
+
+  o.on_tail("--version", "Show version") { puts Astute::VERSION; exit }
   
   o.on("-c", "--command COMMAND", [:provision, :deploy, :provision_and_deploy],
                                     "Select operation: provision, deploy or provision_and_deploy") do |c|
@@ -51,7 +55,7 @@ optparse = OptionParser.new do |o|
 end
 optparse.parse!(ARGV)
 
-if opts[:filename].nil? || opts[:command].nil? 
+if opts[:filename].nil?
   puts optparse
   ERROR_CODE_COMMAND_USAGE = 64
   exit ERROR_CODE_COMMAND_USAGE

--- a/bin/astute
+++ b/bin/astute
@@ -31,7 +31,7 @@ end
 
 opts = {}
 optparse = OptionParser.new do |o|
-  o.banner = "Usage: bin/astute -f FILENAME"
+  o.banner = "Usage: bin/astute -c COMMAND -f FILENAME "
 
   o.on("-v", "--[no-]verbose", "Run verbosely") do |v|
     opts[:verbose] = v
@@ -51,7 +51,7 @@ optparse = OptionParser.new do |o|
 end
 optparse.parse!(ARGV)
 
-if opts[:filename].nil?
+if opts[:filename].nil? || opts[:command].nil? 
   puts optparse
   ERROR_CODE_COMMAND_USAGE = 64
   exit ERROR_CODE_COMMAND_USAGE
@@ -103,7 +103,9 @@ begin
       res
     end
 rescue => e
-  puts "Error: #{e.inspect}"
   result = Astute::FAIL
+  puts "Error: #{e.inspect}"
+  puts "Hint: use astute with --verbose or check log (#{Astute::LOG_PATH}) for more details" unless opts[:verbose]
+  Astute.logger.error e.backtrace.join("\n")
 end
-exit result 
+exit result

--- a/bin/astute
+++ b/bin/astute
@@ -14,16 +14,15 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+if RUBY_VERSION < "1.9"
+  puts "Astute tested and works only on Ruby 1.9.3 but you use #{RUBY_VERSION}"
+  puts "Please run astute using ruby -rubygems bin/astute.rb"
+end
+
 require 'optparse'
 require 'yaml'
-begin
-  require 'astute'
-  require 'astute/version'
-rescue LoadError
-  require 'rubygems'
-  require 'astute'
-  require 'astute/version'
-end
+require 'astute'
+require 'astute/version'
 
 class ConsoleReporter
   def report(msg)

--- a/bin/astute
+++ b/bin/astute
@@ -16,7 +16,7 @@
 
 if RUBY_VERSION < "1.9"
   puts "Astute tested and works only on Ruby 1.9.3 but you use #{RUBY_VERSION}"
-  puts "Please run astute using ruby -rubygems bin/astute.rb"
+  puts "If you still want to try it on older versions of ruby, try 'ruby -rubygems bin/astute'"
 end
 
 require 'optparse'

--- a/lib/astute.rb
+++ b/lib/astute.rb
@@ -42,10 +42,11 @@ module Astute
   
   SUCCESS = 0
   FAIL = 1
+  LOG_PATH = '/var/log/astute.log'
 
   def self.logger
     unless @logger
-      @logger = Logger.new('/var/log/astute.log')
+      @logger = Logger.new(LOG_PATH)
       @logger.formatter = proc do |severity, datetime, progname, msg|
         severity_map = {'DEBUG' => 'debug', 'INFO' => 'info', 'WARN' => 'warning', 'ERROR' => 'err', 'FATAL' => 'crit'}
         "#{datetime.strftime("%Y-%m-%dT%H:%M:%S")} #{severity_map[severity]}: [#{Process.pid}] #{msg}\n"

--- a/lib/astute/logparser.rb
+++ b/lib/astute/logparser.rb
@@ -61,7 +61,7 @@ module Astute
           begin
             progress = (get_log_progress(path, node_pattern_spec)*100).to_i # Return percent of progress
           rescue Exception => e
-            Astute.logger.warn "Some error occurred when calculate progress for node '#{uid}': #{e.message}, trace: #{e.backtrace.inspect}"
+            Astute.logger.warn "Some error occurred when calculate progress for node '#{uid}': #{e.message}, trace: #{e.backtrace.join("\n")}"
             progress = 0
           end
 

--- a/lib/astute/orchestrator.rb
+++ b/lib/astute/orchestrator.rb
@@ -43,7 +43,7 @@ module Astute
       begin
         @log_parser.prepare(nodes)
       rescue Exception => e
-        Astute.logger.warn "Some error occurred when prepare LogParser: #{e.message}, trace: #{e.backtrace.inspect}"
+        Astute.logger.warn "Some error occurred when prepare LogParser: #{e.message}, trace: #{e.backtrace.join("\n")}"
       end
       deploy_engine_instance.deploy(nodes, attrs)
       return SUCCESS
@@ -99,7 +99,7 @@ module Astute
         begin
           provisionLogParser.prepare(nodes)
         rescue => e
-          Astute.logger.warn "Some error occurred when prepare LogParser: #{e.message}, trace: #{e.backtrace.inspect}"
+          Astute.logger.warn "Some error occurred when prepare LogParser: #{e.message}, trace: #{e.backtrace.join("\n")}"
         end
       end
       nodes_not_booted = nodes_uids.clone
@@ -178,7 +178,7 @@ module Astute
       begin
         @log_parser.prepare(nodes)
       rescue Exception => e
-        Astute.logger.warn "Some error occurred when prepare LogParser: #{e.message}, trace: #{e.backtrace.inspect}"
+        Astute.logger.warn "Some error occurred when prepare LogParser: #{e.message}, trace: #{e.backtrace.join("\n")}"
       end
       deploy_engine_instance.deploy(nodes, attrs)
       proxy_reporter.report({'status' => 'ready', 'progress' => 100})
@@ -275,7 +275,7 @@ module Astute
         end
         reporter.report({'nodes' => nodes_progress})
       rescue => e
-        Astute.logger.warn "Some error occurred when parse logs for nodes progress: #{e.message}, trace: #{e.backtrace.inspect}"
+        Astute.logger.warn "Some error occurred when parse logs for nodes progress: #{e.message}, trace: #{e.backtrace.join("\n")}"
       end
     end
     

--- a/lib/astute/puppetd.rb
+++ b/lib/astute/puppetd.rb
@@ -148,7 +148,7 @@ module Astute
               end
             rescue Exception => e
               Astute.logger.warn "Some error occurred when parse logs for nodes progress: #{e.message}, "\
-                                 "trace: #{e.backtrace.inspect}"
+                                 "trace: #{e.backtrace.join("\n")}"
             end
           end
           ctx.reporter.report('nodes' => nodes_to_report) if nodes_to_report.any?


### PR DESCRIPTION
Changes:
- add backtrace information to log and stdout;
- add hint where user can find additional information;
- add version call;
- add information about required -c option to banner.

Example:

```
  [root@fuelweb ~]# astute -f /opt/rbenv/versions/1.9.3-p392/lib/ruby/gems/1.9.1/gems/astute-0.0.1/astute2.yaml -c provision
  {"status"=>"error", "error"=>"Cobbler error", "progress"=>100}
  Error: #<StopIteration: StopIteration>
  Hint: use astute with --verbose or check log (/var/log/astute.log) for more details
```

Log:

```
  2013-07-30T13:10:48 err: [9841] Error occured while provisioning: #<Timeout::Error: execution expired>
  2013-07-30T13:10:48 err: [9841] /opt/rbenv/versions/1.9.3-p392/lib/ruby/gems/1.9.1/gems/astute-0.0.1/lib/astute/orchestrator.rb:68:in `rescue in fast_provision'
  /opt/rbenv/versions/1.9.3-p392/lib/ruby/gems/1.9.1/gems/astute-0.0.1/lib/astute/orchestrator.rb:71:in `fast_provision'
  /opt/rbenv/versions/1.9.3-p392/lib/ruby/gems/1.9.1/gems/astute-0.0.1/bin/astute:85:in `console_provision'
  /opt/rbenv/versions/1.9.3-p392/lib/ruby/gems/1.9.1/gems/astute-0.0.1/bin/astute:101:in `<top (required)>'
  -e:1:in `load'
  -e:1:in `<main>'
```
