### PR TITLE
Remove message check_licenses_success_msg for redhat licenses checking

### DIFF
--- a/lib/astute/redhat_checker.rb
+++ b/lib/astute/redhat_checker.rb
@@ -36,9 +36,6 @@ module Astute
         'https://access.redhat.com/site/solutions/368643. If you are still ' + \
         'encountering issues, contact Mirantis Support.'
 
-      @check_licenses_success_msg = 'Your account appears to be fully entitled ' + \
-        'to deploy Red Hat Openstack.'
-
       @msg_not_enough_licenses = "Your account has only %d licenses " + \
         'available to deploy Red Hat OpenStack. Contact your Red Hat sales ' + \
         'representative to get the proper subscriptions associated with your ' + \
@@ -95,7 +92,7 @@ module Astute
       elsif nodes && licenses_count < nodes.count
         report_success(format(@msg_not_enough_licenses, licenses_count))
       else
-        report_success(@check_licenses_success_msg)
+        report_success
       end
     end
 

--- a/spec/unit/redhat_checker_spec.rb
+++ b/spec/unit/redhat_checker_spec.rb
@@ -107,13 +107,6 @@ describe Astute::RedhatChecker do
   end
 
   describe '#check_redhat_licenses' do
-    let(:success_result) do
-      {
-        'status' => 'ready',
-        'progress' => 100,
-        'msg' => 'Your account appears to be fully entitled to deploy Red Hat Openstack.'
-      }
-    end
 
     describe 'nodes parameter is nil' do
       it_behaves_like 'redhat checker' do


### PR DESCRIPTION
tested by-hand (sent messages directly to rabbit) && unit tests
