### PR TITLE
Feature/dhcp check

### DIFF
--- a/lib/astute/network.rb
+++ b/lib/astute/network.rb
@@ -51,6 +51,20 @@ module Astute
       {'nodes' => result}
     end
 
+
+    def self.check_network(ctx, nodes)
+      uids = nodes.map { |node| node['uid'].to_s }
+      net_probe = MClient.new(ctx, "net_probe", uids)
+      result = []
+      nodes.each do |node|
+        data_to_send = make_interfaces_to_send(node['networks'])
+        net_probe.discover(:nodes => [node['uid'].to_s])
+        response = net_probe.check_dhcp(:interfaces => data_to_send.to_json)
+        result = result + JSON.parse(response)
+
+      end
+    end
+
     private
     def self.start_frame_listeners(ctx, net_probe, nodes)
       nodes.each do |node|

--- a/lib/astute/network.rb
+++ b/lib/astute/network.rb
@@ -59,9 +59,14 @@ module Astute
       nodes.each do |node|
         data_to_send = make_interfaces_to_send(node['networks'], joined=false).to_json
         net_probe.discover(:nodes => [node['uid'].to_s])
+        Astute.logger.debug "prepared data is ready to be send #{data_to_send}"
         response = net_probe.dhcp_discover(:interfaces => data_to_send)
         Astute.logger.debug "Response is ready to be send #{response}"
-        result[response[0][:sender]] = JSON.parse(response[0][:data][:out])
+        begin
+          result[response[0][:sender]] = JSON.parse(response[0][:data][:out])
+        rescue
+          next
+        end
       end
       Astute.logger.debug "data is ready to be send #{result}"
       {'nodes' => result}

--- a/lib/astute/network.rb
+++ b/lib/astute/network.rb
@@ -62,10 +62,10 @@ module Astute
         response = net_probe.dhcp_discover(:interfaces => data_to_send)
         node_result = {:uid => response[0][:sender],
                        :status=>'ready'}
-        if not response[0][:data][:out].empty?
+        if response[0][:data].has_key?(:out) and not response[0][:data][:out].empty?
           Astute.logger.debug("DHCP checker received: node: #{node['uid']} response: #{response}")
           node_result[:data] = JSON.parse(response[0][:data][:out])
-        elsif not response[0][:data][:error].empty?
+        elsif response[0][:data].has_key?(:error) and not response[0][:data][:error].empty?
           node_result[:status] = 'error'
           node_result[:error_msg] = 'Error in dhcp checker. Check logs for details'
         end

--- a/lib/astute/network.rb
+++ b/lib/astute/network.rb
@@ -55,17 +55,16 @@ module Astute
     def self.check_dhcp(ctx, nodes)
       uids = nodes.map { |node| node['uid'].to_s }
       net_probe = MClient.new(ctx, "net_probe", uids)
-      result = []
+      result = {}
       nodes.each do |node|
         data_to_send = make_interfaces_to_send(node['networks'], joined=false).to_json
         net_probe.discover(:nodes => [node['uid'].to_s])
-        Astute.logger.debug "data #{data_to_send}"
         response = net_probe.dhcp_discover(:interfaces => data_to_send)
-        Astute.logger.debug "response #{response}"
-        result = result + response
+        Astute.logger.debug "Response is ready to be send #{response}"
+        result[response[0][:sender]] = JSON.parse(response[0][:data][:out])
       end
       Astute.logger.debug "data is ready to be send #{result}"
-      {'nodes' => result}.to_json
+      {'nodes' => result}
     end
 
     private
@@ -117,6 +116,7 @@ module Astute
         }
       end
     end
+
 
     def self.check_vlans_by_traffic(uids, data)
       data.map do |iface, vlans|

--- a/lib/astute/network.rb
+++ b/lib/astute/network.rb
@@ -61,8 +61,8 @@ module Astute
         net_probe.discover(:nodes => [node['uid'].to_s])
         response = net_probe.check_dhcp(:interfaces => data_to_send.to_json)
         result = result + JSON.parse(response)
-
       end
+      {'nodes': result}.to_json
     end
 
     private

--- a/lib/astute/network.rb
+++ b/lib/astute/network.rb
@@ -62,11 +62,12 @@ module Astute
         response = net_probe.dhcp_discover(:interfaces => data_to_send)
         node_result = {:uid => response[0][:sender],
                        :status=>'ready'}
-        begin
+        if not response[0][:data][:out].empty?
+          Astute.logger.debug("DHCP checker received: node: #{node['uid']} response: #{response}")
           node_result[:data] = JSON.parse(response[0][:data][:out])
-        rescue
+        elsif not response[0][:data][:error].empty?
           node_result[:status] = 'error'
-          node_result[:error_msg] = 'Received corrupted data from dhcp-checker.'
+          node_result[:error_msg] = 'Error in dhcp checker. Check logs for details'
         end
         result << node_result
       end

--- a/lib/astute/orchestrator.rb
+++ b/lib/astute/orchestrator.rb
@@ -163,6 +163,10 @@ module Astute
       Network.check_network(Context.new(task_id, reporter), nodes)
     end
 
+    def check_dhcp(reporter, task_id, nodes)
+      Network.check_dhcp(Context.new(task_id, reporter), nodes)
+    end
+
     def download_release(up_reporter, task_id, release_info)
       raise "Release information not provided!" if release_info.empty?
       attrs = {'deployment_mode' => 'rpmcache',

--- a/mcagents/net_probe.ddl
+++ b/mcagents/net_probe.ddl
@@ -25,3 +25,7 @@ end
 action "echo", :description => "Silly echo" do
     display :always
 end
+
+action "dhcp_discover", :description => "Find dhcp server for provided interfaces" do
+    display :always
+end

--- a/mcagents/net_probe.rb
+++ b/mcagents/net_probe.rb
@@ -45,11 +45,10 @@ module MCollective
         validate :interfaces, String
         format = request.data.key?(:format) ? request.data[:format] : "json"
         timeout = request.data.key?(:timeout) ? request.data[:timeout] : 7
-        interfaces = JSON.parse(request[:interfaces])
-        parsed_interfaces = interfaces.kind_of?(Array) ? interfaces.join(' ') : interfaces
-        cmd = "dhcpcheck discover --format=#{format} --ifaces #{parsed_interfaces} --timeout=#{timeout}"
+        cmd = "dhcpcheck discover --format=#{format} --ifaces #{interfaces_to_string} --timeout=#{timeout}"
         reply[:status] = run(cmd, :stdout => :out, :stderr => :err)
       end
+
 
       private
 
@@ -57,6 +56,14 @@ module MCollective
         File.open('/etc/nailgun_uid') do |fo|
           uid = fo.gets.chomp
           return uid
+        end
+      end
+
+      def interfaces_to_string
+        begin
+          return JSON.parse(request[:interfaces]).join(' ')
+        rescue
+          return request[:interfaces]
         end
       end
 

--- a/mcagents/net_probe.rb
+++ b/mcagents/net_probe.rb
@@ -43,10 +43,9 @@ module MCollective
 
       action "dhcp_discover" do
         validate :interfaces, String
-        Log.info("Interfaces #{request[:interfaces]}")
         format = request.data.key?(:format) ? request.data[:format] : "json"
         timeout = request.data.key?(:timeout) ? request.data[:timeout] : 7
-        cmd = "dhcpcheck discover --format=#{format} --ifaces #{interfaces_to_string} --timeout=#{timeout}"
+        cmd = "dhcpcheck vlans '#{request[:interfaces]}' --timeout=#{timeout} --format=#{format} "
         reply[:status] = run(cmd, :stdout => :out, :stderr => :err)
       end
 

--- a/mcagents/net_probe.rb
+++ b/mcagents/net_probe.rb
@@ -43,6 +43,7 @@ module MCollective
 
       action "dhcp_discover" do
         validate :interfaces, String
+        Log.info("Interfaces #{request[:interfaces]}")
         format = request.data.key?(:format) ? request.data[:format] : "json"
         timeout = request.data.key?(:timeout) ? request.data[:timeout] : 7
         cmd = "dhcpcheck discover --format=#{format} --ifaces #{interfaces_to_string} --timeout=#{timeout}"

--- a/mcagents/net_probe.rb
+++ b/mcagents/net_probe.rb
@@ -43,10 +43,10 @@ module MCollective
 
       action "dhcp_discover" do
         validate :interfaces, String
-        format = conf.key?(:format) ? conf[:format] : "json"
-        timeout = conf.key?(:timeout) ? conf[:timeout] : 7
-
-        cmd = "dhcpcheck discover --format=#{format} --ifaces #{request[:interfaces]} --timeout=#{timeout}"
+        format = request.data.key?(:format) ? request.data[:format] : "json"
+        timeout = request.data.key?(:timeout) ? request.data[:timeout] : 7
+        interfaces = JSON.parse(request[:interfaces])
+        cmd = "dhcpcheck discover --format=#{format} --ifaces #{interfaces} --timeout=#{timeout}"
         reply[:status] = run(cmd, :stdout => :out, :stderr => :err)
       end
 

--- a/mcagents/net_probe.rb
+++ b/mcagents/net_probe.rb
@@ -41,6 +41,15 @@ module MCollective
         stop_frame_listeners
       end
 
+      action "dhcp_discover" do
+        validate :interfaces, String
+        format = conf.key?(:format) ? conf[:format] : "json"
+        timeout = conf.key?(:timeout) ? conf[:timeout] : 7
+
+        cmd = "dhcpcheck discover --format=#{format} --ifaces #{request[:interfaces]} --timeout=#{timeout}"
+        reply[:status] = run(cmd, :stdout => :out, :stderr => :err)
+      end
+
       private
 
       def get_uid

--- a/mcagents/net_probe.rb
+++ b/mcagents/net_probe.rb
@@ -59,14 +59,6 @@ module MCollective
         end
       end
 
-      def interfaces_to_string
-        begin
-          return JSON.parse(request[:interfaces]).join(' ')
-        rescue
-          return request[:interfaces]
-        end
-      end
-
       def start_frame_listeners
         validate :interfaces, String
         config = {

--- a/mcagents/net_probe.rb
+++ b/mcagents/net_probe.rb
@@ -46,7 +46,8 @@ module MCollective
         format = request.data.key?(:format) ? request.data[:format] : "json"
         timeout = request.data.key?(:timeout) ? request.data[:timeout] : 7
         interfaces = JSON.parse(request[:interfaces])
-        cmd = "dhcpcheck discover --format=#{format} --ifaces #{interfaces} --timeout=#{timeout}"
+        parsed_interfaces = interfaces.kind_of?(Array) ? interfaces.join(' ') : interfaces
+        cmd = "dhcpcheck discover --format=#{format} --ifaces #{parsed_interfaces} --timeout=#{timeout}"
         reply[:status] = run(cmd, :stdout => :out, :stderr => :err)
       end
 


### PR DESCRIPTION
Action for net_probe agent
To run it from mco use:
mco rpc --agent=net_probe --action=dhcp_discover --argument interfaces='["eth0", "eth0"]' --argument timeout=10 --argument format=yaml
