### PR TITLE
Multiroles support (part 2)

### DIFF
--- a/lib/astute/deployment_engine.rb
+++ b/lib/astute/deployment_engine.rb
@@ -109,6 +109,7 @@ module Astute
       ctrl_nodes = attrs['nodes'].select {|n| n['role'] == 'controller'}
       if attrs['nodes'].select { |node| node['role'] == 'primary-controller' }.empty?
         ctrl_nodes[0]['role'] = 'primary-controller'
+        nodes[0]['role'] = 'primary-controller'
       end
       attrs['last_controller'] = ctrl_nodes.last['name']
 

--- a/lib/astute/deployment_engine.rb
+++ b/lib/astute/deployment_engine.rb
@@ -105,11 +105,9 @@ module Astute
           'default_gateway'      => n['default_gateway']
         }
       end
-
-      ctrl_nodes = attrs['nodes'].select {|n| n['role'] == 'controller'}
+      ctrl_nodes = attrs['nodes'].select { |n| n['role'] == 'controller' }
       if attrs['nodes'].select { |node| node['role'] == 'primary-controller' }.empty?
-        ctrl_nodes[0]['role'] = 'primary-controller'
-        nodes[0]['role'] = 'primary-controller'
+        ctrl_nodes[0]['role'] = nodes[0]['role'] = 'primary-controller'
       end
       attrs['last_controller'] = ctrl_nodes.last['name']
 

--- a/lib/astute/deployment_engine/nailyfact.rb
+++ b/lib/astute/deployment_engine/nailyfact.rb
@@ -17,19 +17,18 @@ class Astute::DeploymentEngine::NailyFact < Astute::DeploymentEngine
 
   def deploy(nodes, attrs)
     # Convert multi roles node to separate one role nodes
-    nodes.each do |node|
-      next unless node['role'].is_a?(Array)
-      
-      node['role'].each do |role|
+    fuel_nodes = []
+    nodes = nodes.each do |node|
+      node['roles'].each do |role|
         new_node = deep_copy(node)
         new_node['role'] = role
-        nodes << new_node
+        new_node.delete('roles')
+        fuel_nodes << new_node
       end
-      nodes.delete(node)
     end
-
-    attrs_for_mode = self.send("attrs_#{attrs['deployment_mode']}", nodes, attrs)
-    super(nodes, attrs_for_mode)
+    
+    attrs_for_mode = self.send("attrs_#{attrs['deployment_mode']}", fuel_nodes, attrs)
+    super(fuel_nodes, attrs_for_mode)
   end
 
   def create_facts(node, attrs)

--- a/lib/astute/deployment_engine/nailyfact.rb
+++ b/lib/astute/deployment_engine/nailyfact.rb
@@ -95,6 +95,12 @@ class Astute::DeploymentEngine::NailyFact < Astute::DeploymentEngine
     # Prevent attempts to run several deploy on a single node. This is possible because one node 
     # can perform multiple roles.
     group_by_uniq_values(nodes_to_deploy).each do |nodes_group|
+      begin
+        @ctx.deploy_log_parser.prepare(nodes_group)
+      rescue Exception => e
+        Astute.logger.warn "Some error occurred when prepare LogParser: #{e.message}, trace: #{e.format_backtrace}"
+      end
+      
       nodes_group.each do |node|
         node['facts'] = create_facts(node, attrs)
         Astute::Metadata.publish_facts(@ctx, node['uid'], node['facts'])

--- a/lib/astute/deployment_engine/nailyfact.rb
+++ b/lib/astute/deployment_engine/nailyfact.rb
@@ -101,10 +101,8 @@ class Astute::DeploymentEngine::NailyFact < Astute::DeploymentEngine
         Astute.logger.warn "Some error occurred when prepare LogParser: #{e.message}, trace: #{e.format_backtrace}"
       end
       
-      nodes_group.each do |node|
-        node['facts'] = create_facts(node, attrs)
-        Astute::Metadata.publish_facts(@ctx, node['uid'], node['facts'])
-      end
+      nodes_group.each { |node| Astute::Metadata.publish_facts @ctx, node['uid'], create_facts(node, attrs) }
+      
       Astute.logger.info "#{@ctx.task_id}: Required attrs/metadata passed via facts extension. Starting deployment."
 
       Astute::PuppetdDeployer.deploy(@ctx, nodes_group, retries, change_node_status)

--- a/lib/astute/logparser.rb
+++ b/lib/astute/logparser.rb
@@ -138,13 +138,11 @@ module Astute
       def progress_calculate(uids_to_calc, nodes)
         nodes_progress = []
         uids_to_calc.each do |uid|
-          node = nodes.select {|n| n['uid'] == uid}[0]  # NOTE: use nodes hash
+          node = nodes.find {|n| n['uid'] == uid}
+          @nodes_states[uid] ||= deep_copy @pattern_spec
           node_pattern_spec = @nodes_states[uid]
-          unless node_pattern_spec
-            node_pattern_spec = Marshal.load(Marshal.dump(@pattern_spec))
-            @nodes_states[uid] = node_pattern_spec
-          end
-          erb_path = @pattern_spec['path_format']
+          
+          erb_path = node_pattern_spec['path_format']
           path = ERB.new(erb_path).result(binding())
           begin
             progress = (get_log_progress(path, node_pattern_spec)*100).to_i # Return percent of progress

--- a/lib/astute/logparser/deployment.rb
+++ b/lib/astute/logparser/deployment.rb
@@ -32,13 +32,12 @@ module Astute
       def progress_calculate(uids_to_calc, nodes)
         # Just create correct pattern for each node and then call parent method.
         uids_to_calc.each do |uid|
-          node = nodes.select {|n| n['uid'] == uid}[0]
+          node = nodes.find {|n| n['uid'] == uid}
           unless @nodes_states[uid]
-            pattern_spec = Patterns::get_default_pattern(
+            @nodes_states[uid] = Patterns::get_default_pattern(
               "puppet-log-components-list-#{@deploy_type}-#{node['role']}")
-            pattern_spec['path_prefix'] ||= PATH_PREFIX.to_s
-            pattern_spec['separator'] ||= SEPARATOR.to_s
-            @nodes_states[uid] = pattern_spec
+            @nodes_states[uid]['path_prefix'] ||= PATH_PREFIX.to_s
+            @nodes_states[uid]['separator'] ||= SEPARATOR.to_s
           end
         end
         super(uids_to_calc, nodes)

--- a/lib/astute/logparser/provision.rb
+++ b/lib/astute/logparser/provision.rb
@@ -26,10 +26,8 @@ module Astute
       def progress_calculate(uids_to_calc, nodes)
         # Just create correct pattern for each node and then call parent method.
         uids_to_calc.each do |uid|
-          node = nodes.select {|n| n['uid'] == uid}[0]
-          unless @nodes_states[uid]
-            @nodes_states[uid] = get_pattern_for_node(node)
-          end
+          node = nodes.find {|n| n['uid'] == uid}
+          @nodes_states[uid] ||= get_pattern_for_node(node)
         end
         super(uids_to_calc, nodes)
       end

--- a/lib/astute/orchestrator.rb
+++ b/lib/astute/orchestrator.rb
@@ -41,6 +41,7 @@ module Astute
       context = Context.new(task_id, proxy_reporter, log_parser)
       deploy_engine_instance = @deploy_engine.new(context)
       Astute.logger.info "Using #{deploy_engine_instance.class} for deployment."
+      deploy_engine_instance.deploy(nodes, attrs)
       return SUCCESS
     end
 

--- a/lib/astute/orchestrator.rb
+++ b/lib/astute/orchestrator.rb
@@ -41,12 +41,6 @@ module Astute
       context = Context.new(task_id, proxy_reporter, log_parser)
       deploy_engine_instance = @deploy_engine.new(context)
       Astute.logger.info "Using #{deploy_engine_instance.class} for deployment."
-      begin
-        log_parser.prepare(nodes)
-      rescue Exception => e
-        Astute.logger.warn "Some error occurred when prepare LogParser: #{e.message}, trace: #{e.format_backtrace}"
-      end
-      deploy_engine_instance.deploy(nodes, attrs)
       return SUCCESS
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -77,5 +77,14 @@ module SpecHelpers
 
     ctx
   end
+  
+  # Transform fixtures from nailgun format node['roles'] array to node['role'] string
+  def nodes_with_role(data, role)
+    role_nodes = data['args']['nodes'].select { |n| n['roles'].include? role }
+    deep_copy(role_nodes).each do |n| 
+      n['role'] = role
+      n.delete('roles')
+    end
+  end
 
 end

--- a/spec/unit/deployment_engine_spec.rb
+++ b/spec/unit/deployment_engine_spec.rb
@@ -23,30 +23,33 @@ describe Astute::DeploymentEngine do
   let(:ctx) { mock_ctx }
   let(:deployer) { Engine.new(ctx) }
 
-  describe '#attrs_ha' do
-
-    def only_controllers(nodes)
-      nodes.select { |node| node['role'] == 'controller' }
+  describe '#attrs_ha' do 
+    let(:ha_nodes) do
+      nodes_with_role(Fixtures.ha_attrs, 'controller')
     end
 
     it 'should set last_controller' do
-      attrs = deployer.attrs_ha(Fixtures.ha_nodes, {})
-      attrs['last_controller'].should == only_controllers(Fixtures.ha_nodes).last['fqdn'].split(/\./)[0]
+      attrs = deployer.attrs_ha(ha_nodes, {})
+      attrs['last_controller'].should == ha_nodes.last['fqdn'].split(/\./)[0]
+    end
+    
+    it 'should set last_controller when contoller only one' do
+      single_controller = ha_nodes.shift
+      attrs = deployer.attrs_ha([single_controller], {})
+      attrs['last_controller'].should == single_controller['fqdn'].split(/\./)[0]
     end
 
     it 'should assign primary-controller role for first node if primary-controller not set directly' do
-      attrs = deployer.attrs_ha(Fixtures.ha_nodes, {})
+      attrs = deployer.attrs_ha(ha_nodes, {})
       primary = attrs['nodes'].find { |node| node['role'] == 'primary-controller' }
       primary.should_not be_nil
-      primary['fqdn'].should == only_controllers(Fixtures.ha_nodes).first['fqdn']
+      primary['fqdn'].should == ha_nodes.first['fqdn']
     end
 
     it 'should not assign primary-controller role for first node if primary-controller set directly' do
-      nodes = Fixtures.ha_nodes
-      last_node = only_controllers(nodes).last
+      last_node = ha_nodes.last
       last_node['role'] = 'primary-controller'
-      attrs = deployer.attrs_ha(deep_copy(nodes), {})
-
+      attrs = deployer.attrs_ha(deep_copy(ha_nodes), {})
       primary = attrs['nodes'].select { |node| node['role'] == 'primary-controller' }
       primary.length.should == 1
       primary[0]['fqdn'].should == last_node['fqdn']

--- a/spec/unit/fixtures/common_attrs.rb
+++ b/spec/unit/fixtures/common_attrs.rb
@@ -48,11 +48,18 @@ module Fixtures
         },
         "task_uuid" => "19d99029-350a-4c9c-819c-1f294cf9e741",
         "nodes" => Fixtures.common_nodes,
-        "controller_nodes" => Fixtures.common_nodes.select { |node| node['role'] == 'controller'}
+        "controller_nodes" => controller_nodes(Fixtures.common_nodes)
       },
       "method" => "deploy",
       "respond_to" => "deploy_resp"
     }
   end
-
+  
+  def self.controller_nodes(nodes)
+    controller_nodes = nodes.select{|n| n['roles'].include?('controller')}.map { |e| deep_copy e }
+    controller_nodes.each do |n| 
+      n['role'] = 'controller'
+      n.delete('roles')
+    end
+  end
 end

--- a/spec/unit/fixtures/common_nodes.rb
+++ b/spec/unit/fixtures/common_nodes.rb
@@ -59,7 +59,7 @@ module Fixtures
         ],
         "id" => 1,
         "ip" => "10.20.0.200",
-        "role" => "controller",
+        "roles" => ["controller"],
         'meta' => meta
       }, {
         "mac" => "52:54:00:50:91:DD",
@@ -107,7 +107,7 @@ module Fixtures
         ],
         "id" => 2,
         "ip" => "10.20.0.221",
-        "role" => "compute",
+        "roles" => ["compute"],
         'meta' => meta
       }, {
         "mac" => "52:54:00:C3:2C:28",
@@ -155,7 +155,7 @@ module Fixtures
         ],
         "id" => 3,
         "ip" => "10.20.0.68",
-        "role" => "compute",
+        "roles" => ["compute"],
         'meta' => meta
       }
     ]

--- a/spec/unit/fixtures/common_nodes.rb
+++ b/spec/unit/fixtures/common_nodes.rb
@@ -20,9 +20,9 @@ module Fixtures
       {
         "mac" => "52:54:00:0E:B8:F5",
         "status" => "provisioning",
-        "uid" => "devnailgun.mirantis.com",
+        "uid" => "1",
         "error_type" => nil,
-        "fqdn" => "devnailgun.mirantis.com",
+        "fqdn" => "controller-1.mirantis.com",
         "network_data" => [
           {
             "gateway" => "192.168.0.1",
@@ -66,7 +66,7 @@ module Fixtures
         "status" => "provisioning",
         "uid" => 2,
         "error_type" => nil,
-        "fqdn" => "slave-2.mirantis.com",
+        "fqdn" => "compute-2.mirantis.com",
         "network_data" => [
           {
             "gateway" => "192.168.0.1",
@@ -114,7 +114,7 @@ module Fixtures
         "status" => "provisioning",
         "uid" => 3,
         "error_type" => nil,
-        "fqdn" => "slave-3.mirantis.com",
+        "fqdn" => "compute-3.mirantis.com",
         "network_data" => [
           {
             "gateway" => "192.168.0.1",

--- a/spec/unit/fixtures/ha_attrs.rb
+++ b/spec/unit/fixtures/ha_attrs.rb
@@ -18,7 +18,7 @@ module Fixtures
   def self.ha_attrs
     attrs = common_attrs
 
-    attrs['args']['nodes'] = common_nodes + ha_nodes
+    attrs['args']['nodes'] = ha_nodes
     attrs['args']['attributes']['deployment_mode'] = "ha"
     attrs['args']['attributes']['management_vip'] = "192.168.0.111"
     attrs['args']['attributes']['public_vip'] = "240.0.1.111"

--- a/spec/unit/fixtures/ha_attrs.rb
+++ b/spec/unit/fixtures/ha_attrs.rb
@@ -19,9 +19,11 @@ module Fixtures
     attrs = common_attrs
 
     attrs['args']['nodes'] = ha_nodes
+    
     attrs['args']['attributes']['deployment_mode'] = "ha"
     attrs['args']['attributes']['management_vip'] = "192.168.0.111"
     attrs['args']['attributes']['public_vip'] = "240.0.1.111"
+    attrs['args']["controller_nodes"] = controller_nodes(attrs['args']['nodes'])
 
     attrs
   end

--- a/spec/unit/fixtures/ha_nodes.rb
+++ b/spec/unit/fixtures/ha_nodes.rb
@@ -63,7 +63,7 @@ module Fixtures
         ],
         "id" => 4,
         "ip" => "10.20.0.205",
-        "role" => "controller",
+        "roles" => ["controller"],
         'meta' => meta
       },
       {
@@ -112,7 +112,7 @@ module Fixtures
         ],
         "id" => 5,
         "ip" => "10.20.0.206",
-        "role" => "controller",
+        "roles" => ["controller"],
         'meta' => meta
       }
     ]

--- a/spec/unit/fixtures/mr_nodes.rb
+++ b/spec/unit/fixtures/mr_nodes.rb
@@ -64,7 +64,7 @@ module Fixtures
         ],
         "id" => 6,
         "ip" => "10.20.0.205",
-        "role" => 
+        "roles" => 
           [
             "controller",
             "compute"
@@ -72,9 +72,7 @@ module Fixtures
         'meta' => meta
       }
     ]
-    controller_nodes = attrs['args']['nodes'].select{|n| n['role'].include?('controller')}.map { |e| deep_copy e }
-    controller_nodes.each {|n| n['role'] = 'controller' }
-    attrs['args']['controller_nodes'] = controller_nodes
+    attrs['args']['controller_nodes'] = controller_nodes(attrs['args']['nodes'])
     attrs
   end
 

--- a/spec/unit/fixtures/mr_nodes.rb
+++ b/spec/unit/fixtures/mr_nodes.rb
@@ -21,7 +21,7 @@ module Fixtures
       {
         "mac" => "52:54:00:0E:88:88",
         "status" => "provisioned",
-        "uid" => "4",
+        "uid" => "6",
         "error_type" => nil,
         "fqdn" => "controller_compute-4.mirantis.com",
         "network_data" => [
@@ -62,7 +62,7 @@ module Fixtures
             "brd" => "172.16.1.255"
           }
         ],
-        "id" => 4,
+        "id" => 6,
         "ip" => "10.20.0.205",
         "role" => 
           [

--- a/spec/unit/nailyfact_deploy_spec.rb
+++ b/spec/unit/nailyfact_deploy_spec.rb
@@ -16,6 +16,8 @@
 require File.join(File.dirname(__FILE__), '../spec_helper')
 
 describe "NailyFact DeploymentEngine" do
+  include SpecHelpers
+  
   context "When deploy is called, " do
     before(:each) do
       @ctx = mock
@@ -25,14 +27,22 @@ describe "NailyFact DeploymentEngine" do
       @ctx.stubs(:reporter).returns(reporter)
       reporter.stubs(:report)
       @deploy_engine = Astute::DeploymentEngine::NailyFact.new(@ctx)
-
-      @data = Fixtures.common_attrs
-      @data_ha = Fixtures.ha_attrs
-      @data_mr = Fixtures.multiroles_attrs
+    end
+    
+    let(:controller_nodes) do
+      nodes_with_role(deploy_data, 'controller')
+    end
+    
+    let(:compute_nodes) do 
+      nodes_with_role(deploy_data, 'compute')
+    end
+    
+    let(:cinder_nodes) do 
+      nodes_with_role(deploy_data, 'cinder')
     end
 
     it "it should call valid method depends on attrs" do
-      nodes = [{'uid' => 1}]
+      nodes = [{'uid' => 1, 'role' => 'controller'}]
       attrs = {'deployment_mode' => 'ha'}
       attrs_modified = attrs.merge({'some' => 'somea'})
 
@@ -40,57 +50,52 @@ describe "NailyFact DeploymentEngine" do
       @deploy_engine.expects(:deploy_ha).with(nodes, attrs_modified)
       # All implementations of deploy_piece go to subclasses
       @deploy_engine.respond_to?(:deploy_piece).should be_true
-      @deploy_engine.deploy(nodes, attrs)
+      
+      external_nodes = [{'uid' => 1, 'roles' => ['controller']}]
+      @deploy_engine.deploy(external_nodes, attrs)
     end
 
     it "it should raise an exception if deployment mode is unsupported" do
-      nodes = [{'uid' => 1}]
+      nodes = [{'uid' => 1, 'roles' => ['controller']}]
       attrs = {'deployment_mode' => 'unknown'}
       expect {@deploy_engine.deploy(nodes, attrs)}.to raise_exception(/Method attrs_unknown is not implemented/)
     end
 
-    it "multinode deploy should not raise any exception" do
-      @data['args']['attributes']['deployment_mode'] = "multinode"
-      Astute::Metadata.expects(:publish_facts).times(@data['args']['nodes'].size)
-      # we got two calls, one for controller, and another for all computes
-      controller_nodes = @data['args']['nodes'].select{|n| n['role'] == 'controller'}
-      compute_nodes = @data['args']['nodes'].select{|n| n['role'] == 'compute'}
-      Astute::PuppetdDeployer.expects(:deploy).with(@ctx, controller_nodes, instance_of(Fixnum), true).once
-      Astute::PuppetdDeployer.expects(:deploy).with(@ctx, compute_nodes, instance_of(Fixnum), true).once
-      @deploy_engine.deploy(@data['args']['nodes'], @data['args']['attributes'])
+    context 'multinode deploy ' do
+      let(:deploy_data) do
+        Fixtures.common_attrs
+      end
+
+      it "should not raise any exception" do
+        deploy_data['args']['attributes']['deployment_mode'] = "multinode"
+        Astute::Metadata.expects(:publish_facts).times(deploy_data['args']['nodes'].size)
+        # we got two calls, one for controller, and another for all computes
+        Astute::PuppetdDeployer.expects(:deploy).with(@ctx, controller_nodes, instance_of(Fixnum), true).once
+        Astute::PuppetdDeployer.expects(:deploy).with(@ctx, compute_nodes, instance_of(Fixnum), true).once
+        @deploy_engine.deploy(deploy_data['args']['nodes'], deploy_data['args']['attributes'])
+      end
     end
     
-    context 'multiroles support' do     
-      before(:each) do
-        @data_mr['args']['attributes']['deployment_mode'] = "multinode"
-        # This role have same priority for multinode mode
-        @data_mr['args']['nodes'][0]['role'] = ['compute', 'cinder'] 
-      end
-      
-      let(:compute_nodes) do 
-        compute_nodes = @data_mr['args']['nodes'].select{|n| n['role'].include? 'compute'}
-        deep_copy(compute_nodes).each{ |n| n['role'] = 'compute'}
+    context 'multiroles support' do
+      let(:deploy_data) do
+        data = Fixtures.multiroles_attrs
+        data['args']['attributes']['deployment_mode'] = "multinode"
+         # This role have same priority for multinode mode
+        data['args']['nodes'][0]['roles'] = ['compute', 'cinder']
+        data
       end
     
-      let(:node_amount) { @data_mr['args']['nodes'][0]['role'].size }
+      let(:node_amount) { deploy_data['args']['nodes'][0]['roles'].size }
       
       it "multiroles for node should be support" do
-        @data_mr['args']['nodes'][0]['role'] = ['controller', 'compute'] 
-
-        controller_nodes = @data_mr['args']['nodes'].select{|n| n['role'].include? 'controller'}
-        controller_nodes = deep_copy(controller_nodes).each{ |n| n['role'] = 'controller'}
+        deploy_data['args']['nodes'][0]['roles'] = ['controller', 'compute'] 
         
         # we got two calls, one for controller, and another for all(1) computes
         Astute::Metadata.expects(:publish_facts).times(node_amount)
         Astute::PuppetdDeployer.expects(:deploy).with(@ctx, controller_nodes, instance_of(Fixnum), true).once
         Astute::PuppetdDeployer.expects(:deploy).with(@ctx, compute_nodes, instance_of(Fixnum), true).once
       
-        @deploy_engine.deploy(@data_mr['args']['nodes'], @data_mr['args']['attributes'])
-      end
-    
-      let(:cinder_nodes) do 
-        cinder_nodes = @data_mr['args']['nodes'].select{|n| n['role'].include? 'cinder'}
-        deep_copy(cinder_nodes).each{ |n| n['role'] = 'cinder'}
+        @deploy_engine.deploy(deploy_data['args']['nodes'], deploy_data['args']['attributes'])
       end
     
       it "roles with the same priority for one node should deploy in series" do
@@ -101,7 +106,7 @@ describe "NailyFact DeploymentEngine" do
         Astute::PuppetdDeployer.expects(:deploy).with(@ctx, compute_nodes, instance_of(Fixnum), true).once
         Astute::PuppetdDeployer.expects(:deploy).with(@ctx, cinder_nodes, instance_of(Fixnum), true).once
       
-        @deploy_engine.deploy(@data_mr['args']['nodes'], @data_mr['args']['attributes'])
+        @deploy_engine.deploy(deploy_data['args']['nodes'], deploy_data['args']['attributes'])
       end
     
       it "should prepare log parsing for every deploy call because node may be deployed several times" do
@@ -111,7 +116,7 @@ describe "NailyFact DeploymentEngine" do
       
         Astute::PuppetdDeployer.expects(:deploy).times(2)
        
-        @deploy_engine.deploy(@data_mr['args']['nodes'], @data_mr['args']['attributes'])
+        @deploy_engine.deploy(deploy_data['args']['nodes'], deploy_data['args']['attributes'])
       end
     
       it "should generate and publish facts for every deploy call because node may be deployed several times" do        
@@ -121,32 +126,37 @@ describe "NailyFact DeploymentEngine" do
       
         Astute::PuppetdDeployer.expects(:deploy).times(2)
        
-        @deploy_engine.deploy(@data_mr['args']['nodes'], @data_mr['args']['attributes'])
+        @deploy_engine.deploy(deploy_data['args']['nodes'], deploy_data['args']['attributes'])
       end
     end
-
-    it "ha deploy should not raise any exception" do
-      Astute::Metadata.expects(:publish_facts).at_least_once
-      controller_nodes = @data_ha['args']['nodes'].select{|n| n['role'] == 'controller'}
-      primary_controller = controller_nodes.shift
-      primary_controller = deep_copy primary_controller
-      primary_controller['role'] = 'primary-controller'
-      compute_nodes = @data_ha['args']['nodes'].select{|n| n['role'] == 'compute'}
-      
-      Astute::PuppetdDeployer.expects(:deploy).with(@ctx, [primary_controller], 2, true).once
-      controller_nodes.each do |n|
-        Astute::PuppetdDeployer.expects(:deploy).with(@ctx, [n], 2, true).once
+    
+    context 'ha deploy' do
+      let(:deploy_data) do
+        Fixtures.ha_attrs
       end
-      Astute::PuppetdDeployer.expects(:deploy).with(@ctx, compute_nodes, instance_of(Fixnum), true).once
-      
-      @deploy_engine.deploy(@data_ha['args']['nodes'], @data_ha['args']['attributes'])
-    end
 
-    it "ha deploy should not raise any exception if there are only one controller" do
-      Astute::Metadata.expects(:publish_facts).at_least_once
-      Astute::PuppetdDeployer.expects(:deploy).once
-      ctrl = @data_ha['args']['nodes'].select {|n| n['role'] == 'controller'}[0]
-      @deploy_engine.deploy([ctrl], @data_ha['args']['attributes'])
+      it "ha deploy should not raise any exception" do
+        Astute::Metadata.expects(:publish_facts).at_least_once
+        
+        primary_controller = controller_nodes.shift
+        primary_controller['role'] = 'primary-controller'
+        primary_controller.delete('roles')
+        
+        Astute::PuppetdDeployer.expects(:deploy).with(@ctx, [primary_controller], 2, true).once
+        controller_nodes.each do |n|
+          Astute::PuppetdDeployer.expects(:deploy).with(@ctx, [n], 2, true).once
+        end
+        Astute::PuppetdDeployer.expects(:deploy).with(@ctx, compute_nodes, instance_of(Fixnum), true).once
+      
+        @deploy_engine.deploy(deploy_data['args']['nodes'], deploy_data['args']['attributes'])
+      end
+
+      it "ha deploy should not raise any exception if there are only one controller" do
+        Astute::Metadata.expects(:publish_facts).at_least_once
+        Astute::PuppetdDeployer.expects(:deploy).once
+        ctrl = deploy_data['args']['nodes'].find { |n| n['roles'].include? 'controller' }
+        @deploy_engine.deploy([ctrl], deploy_data['args']['attributes'])
+      end
     end
 
     describe 'Vlan manager' do


### PR DESCRIPTION
Changes:
- support deploy for nodes with same priority (for example, compute and cinder);
- add tests and small refactoring of fixtures;
- change behavior of log parsing to support multi roles;
- small refactoring of log parsing;
- fix bug with primary-controller deploy (never call as separate deploy for HA if role has not been clearly defined)

Notices:
- In this pull still exist behavior with sending 'ready' status for multi role node several times;
- not yet testing using system and manual tests (in progress).
