### PR TITLE
Rcov tests

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -8,14 +8,11 @@ set -e
 # change dir to the path of the directory in which a current bash script is located
 # source: http://stackoverflow.com/a/179231/842168
 function cd_workspace() {
-  pushd . > /dev/null
   SCRIPT_PATH="${BASH_SOURCE[0]}";
   if ([ -h "${SCRIPT_PATH}" ]) then
     while([ -h "${SCRIPT_PATH}" ]) do cd `dirname "$SCRIPT_PATH"`; SCRIPT_PATH=`readlink "${SCRIPT_PATH}"`; done
   fi
   cd `dirname ${SCRIPT_PATH}` > /dev/null
-  SCRIPT_PATH=`pwd`;
-  popd  > /dev/null
 }
 
 function license_check() {

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,10 +1,26 @@
 #!/bin/bash
 # astute_rspec_check.sh
+# RVM
+source ~/.bash_profile
+
 set -e
+
+# change dir to the path of the directory in which a current bash script is located
+# source: http://stackoverflow.com/a/179231/842168
+function cd_workspace() {
+  pushd . > /dev/null
+  SCRIPT_PATH="${BASH_SOURCE[0]}";
+  if ([ -h "${SCRIPT_PATH}" ]) then
+    while([ -h "${SCRIPT_PATH}" ]) do cd `dirname "$SCRIPT_PATH"`; SCRIPT_PATH=`readlink "${SCRIPT_PATH}"`; done
+  fi
+  cd `dirname ${SCRIPT_PATH}` > /dev/null
+  SCRIPT_PATH=`pwd`;
+  popd  > /dev/null
+}
 
 function license_check() {
   # License information must be in every source file
-  cd $WORKSPACE
+  cd_workspace
   
   tmpfile=`tempfile`
   find * -not -path "docs/*" -regex ".*\.\(rb\)" -type f -print0 | xargs -0 grep -Li License
@@ -19,10 +35,10 @@ function license_check() {
 }
 
 function ruby_checks() {
-  cd $WORKSPACE
+  cd_workspace
   
-  # Install all ruby dependencies
-  sudo bundle install
+  # Install all ruby dependencies (expect ruby version manager: RVM, rbenv or similar)
+  bundle install
   
   # Run unit rspec tests
   bundle exec rake spec:unit


### PR DESCRIPTION
- use ruby version manager instead of system ruby (1.9.3 instead of 1.8.7, do not use sudo, support Rcov generation);
- use dynamic determination of the current bash scrip directory (work in MacOS and FreeBSD also, available to run in subdirectory of jennins workspace).

Example:
https://fuel-jenkins.mirantis.com/job/astute-rspec-check/48/
