### PR TITLE
Astute refactoring (method names for provision)

### DIFF
--- a/bin/astute
+++ b/bin/astute
@@ -97,14 +97,11 @@ if [:deploy, :provision, :provision_and_deploy].include? opts[:command]
 end
 
 def console_provision(orchestrator, reporter, environment)
-  res = orchestrator.fast_provision(reporter, environment['engine'], environment['nodes'])
-  if res == Astute::SUCCESS
-    puts "restarting nodes..."
-    sleep 5
-    puts "start watching progress"
-    res = orchestrator.provision(reporter, environment['task_uuid'], environment['nodes'])
-  end
-  res
+  orchestrator.provision(reporter, environment['engine'], environment['nodes'])
+  puts "restarting nodes..."
+  sleep 5
+  puts "start watching progress"
+  orchestrator.watch_provision_progress(reporter, environment['task_uuid'], environment['nodes'])
 end
 
 result = Astute::SUCCESS

--- a/lib/astute/deployment_engine/nailyfact.rb
+++ b/lib/astute/deployment_engine/nailyfact.rb
@@ -42,7 +42,7 @@ class Astute::DeploymentEngine::NailyFact < Astute::DeploymentEngine
 
     begin
       @ctx.deploy_log_parser.prepare(nodes_to_deploy)
-    rescue Exception => e
+    rescue => e
       Astute.logger.warn "Some error occurred when prepare LogParser: #{e.message}, trace: #{e.format_backtrace}"
     end
 

--- a/lib/astute/logparser.rb
+++ b/lib/astute/logparser.rb
@@ -146,7 +146,7 @@ module Astute
           path = ERB.new(erb_path).result(binding())
           begin
             progress = (get_log_progress(path, node_pattern_spec)*100).to_i # Return percent of progress
-          rescue Exception => e
+          rescue => e
             Astute.logger.warn "Some error occurred when calculate progress for node '#{uid}': #{e.message}, trace: #{e.format_backtrace}"
             progress = 0
           end

--- a/lib/astute/orchestrator.rb
+++ b/lib/astute/orchestrator.rb
@@ -194,7 +194,7 @@ module Astute
       rescue Astute::RedhatCheckingError => e
         Astute.logger.error("Error #{e.message}")
         raise e
-      rescue Exception => e
+      rescue => e
         Astute.logger.error("Unexpected error #{e.message} traceback #{e.format_backtrace}")
         raise e
       end
@@ -207,7 +207,7 @@ module Astute
       rescue Astute::RedhatCheckingError => e
         Astute.logger.error("Error #{e.message}")
         raise e
-      rescue Exception => e
+      rescue => e
         Astute.logger.error("Unexpected error #{e.message} traceback #{e.format_backtrace}")
         raise e
       end
@@ -227,7 +227,7 @@ module Astute
       time = Time.now.to_f
       block.call
       time = time + sleep_time - Time.now.to_f
-      sleep (time) if time > 0
+      sleep(time) if time > 0
     end
 
     def create_engine(engine_attrs, reporter)
@@ -261,12 +261,10 @@ module Astute
     end
         
     def reboot_nodes(engine, nodes)
-      reboot_events = {}
-      nodes.each do |node|
+      nodes.inject({}) do |reboot_events, node|
         Astute.logger.debug("Trying to reboot node: #{node['name']}")
-        reboot_events[node['name']] = engine.power_reboot(node['name'])
+        reboot_events.merge(node['name'] => engine.power_reboot(node['name']))
       end
-      reboot_events
     end
 
     def check_reboot_nodes(engine, reboot_events)

--- a/lib/astute/orchestrator.rb
+++ b/lib/astute/orchestrator.rb
@@ -43,15 +43,17 @@ module Astute
       context.status
     end
 
-    def fast_provision(reporter, engine_attrs, nodes)
-      raise "Nodes to provision are not provided!" if nodes.empty?
+    def provision(reporter, engine_attrs, nodes_for_provision)
+      raise "Nodes to provision are not provided!" if nodes_for_provision.empty?
+      
+      # We need only those which are not ready/provisioned yet
+      nodes = nodes_for_provision.select { |n| !['provisioned', 'ready'].include?(n['status']) }
 
       engine = create_engine(engine_attrs, reporter)
-
       begin
+        add_nodes_to_cobbler(engine, nodes)
         reboot_events = reboot_nodes(engine, nodes)
         failed_nodes  = check_reboot_nodes(engine, reboot_events)
-
       rescue RuntimeError => e
         Astute.logger.error("Error occured while provisioning: #{e.inspect}")
         reporter.report({
@@ -59,14 +61,13 @@ module Astute
                           'error' => 'Cobbler error',
                           'progress' => 100
                         })
-        raise StopIteration
+        raise e
       ensure
         engine.sync
       end
 
       if failed_nodes.empty?
         report_result({}, reporter)
-        return SUCCESS
       else
         Astute.logger.error("Nodes failed to reboot: #{failed_nodes.inspect}")
         reporter.report({
@@ -74,18 +75,12 @@ module Astute
                           'error' => "Nodes failed to reboot: #{failed_nodes.inspect}",
                           'progress' => 100
                         })
-        raise StopIteration
+        raise e
       end
     end
 
-    def provision(reporter, task_id, nodes_up)
-      raise "Nodes to provision are not provided!" if nodes_up.empty?
-
-      # We need only those which are not ready/provisioned yet
-      nodes = []
-      nodes_up.each do |n|
-        nodes << n unless ['provisioned', 'ready'].include?(n['status'])
-      end
+    def watch_provision_progress(reporter, task_id, nodes)
+      raise "Nodes to provision are not provided!" if nodes.empty?
 
       nodes_uids = nodes.map { |n| n['uid'] }
 
@@ -198,10 +193,10 @@ module Astute
         Astute::RedhatChecker.new(ctx, credentials).check_redhat_credentials
       rescue Astute::RedhatCheckingError => e
         Astute.logger.error("Error #{e.message}")
-        raise StopIteration
+        raise e
       rescue Exception => e
         Astute.logger.error("Unexpected error #{e.message} traceback #{e.format_backtrace}")
-        raise StopIteration
+        raise e
       end
     end
 
@@ -211,10 +206,10 @@ module Astute
         Astute::RedhatChecker.new(ctx, credentials).check_redhat_licenses(nodes)
       rescue Astute::RedhatCheckingError => e
         Astute.logger.error("Error #{e.message}")
-        raise StopIteration
+        raise e
       rescue Exception => e
         Astute.logger.error("Unexpected error #{e.message} traceback #{e.format_backtrace}")
-        raise StopIteration
+        raise e
       end
     end
 
@@ -236,23 +231,23 @@ module Astute
     end
 
     def create_engine(engine_attrs, reporter)
+      raise "Settings for Cobbler must be set" if engine_attrs.blank?
+      
       begin
         Astute.logger.info("Trying to instantiate cobbler engine: #{engine_attrs.inspect}")
         Astute::Provision::Cobbler.new(engine_attrs)
-      rescue
+      rescue => e
         Astute.logger.error("Error occured during cobbler initializing")
-
         reporter.report({
                           'status' => 'error',
                           'error' => 'Cobbler can not be initialized',
                           'progress' => 100
                         })
-        raise StopIteration
+        raise e
       end
     end
 
-    def reboot_nodes(engine, nodes)
-      reboot_events = {}
+    def add_nodes_to_cobbler(engine, nodes)
       nodes.each do |node|
         begin
           Astute.logger.info("Adding #{node['name']} into cobbler")
@@ -262,6 +257,12 @@ module Astute
           Astute.logger.error("Error occured while adding system #{node['name']} to cobbler")
           raise e
         end
+      end # end iteration
+    end
+        
+    def reboot_nodes(engine, nodes)
+      reboot_events = {}
+      nodes.each do |node|
         Astute.logger.debug("Trying to reboot node: #{node['name']}")
         reboot_events[node['name']] = engine.power_reboot(node['name'])
       end

--- a/lib/astute/orchestrator.rb
+++ b/lib/astute/orchestrator.rb
@@ -43,11 +43,8 @@ module Astute
       context.status
     end
 
-    def provision(reporter, engine_attrs, nodes_for_provision)
-      raise "Nodes to provision are not provided!" if nodes_for_provision.empty?
-      
-      # We need only those which are not ready/provisioned yet
-      nodes = nodes_for_provision.select { |n| !['provisioned', 'ready'].include?(n['status']) }
+    def provision(reporter, engine_attrs, nodes)
+      raise "Nodes to provision are not provided!" if nodes.empty?
 
       engine = create_engine(engine_attrs, reporter)
       begin

--- a/lib/astute/orchestrator.rb
+++ b/lib/astute/orchestrator.rb
@@ -193,7 +193,7 @@ module Astute
         Astute::RedhatChecker.new(ctx, credentials).check_redhat_credentials
       rescue Astute::RedhatCheckingError => e
         Astute.logger.error("Error #{e.message}")
-        raise e
+        raise StopIteration
       rescue => e
         Astute.logger.error("Unexpected error #{e.message} traceback #{e.format_backtrace}")
         raise e
@@ -206,7 +206,7 @@ module Astute
         Astute::RedhatChecker.new(ctx, credentials).check_redhat_licenses(nodes)
       rescue Astute::RedhatCheckingError => e
         Astute.logger.error("Error #{e.message}")
-        raise e
+        raise StopIteration
       rescue => e
         Astute.logger.error("Unexpected error #{e.message} traceback #{e.format_backtrace}")
         raise e

--- a/lib/astute/puppetd.rb
+++ b/lib/astute/puppetd.rb
@@ -146,7 +146,7 @@ module Astute
                 nodes_progress.map! {|x| x.merge!({'status' => 'deploying'})}
                 nodes_to_report += nodes_progress
               end
-            rescue Exception => e
+            rescue => e
               Astute.logger.warn "Some error occurred when parse logs for nodes progress: #{e.message}, "\
                                  "trace: #{e.format_backtrace}"
             end

--- a/lib/astute/redhat_checker.rb
+++ b/lib/astute/redhat_checker.rb
@@ -17,7 +17,7 @@
 
 module Astute
 
-  class RedhatCheckingError < Exception; end
+  class RedhatCheckingError < StandardError; end
 
   class RedhatChecker
 

--- a/spec/unit/cobbler_spec.rb
+++ b/spec/unit/cobbler_spec.rb
@@ -45,12 +45,11 @@ describe Cobbler do
   end
 
   it "should be able to be initialized with 'host', 'port', 'path'" do
-    host = "host.domain.tld"
-    port = "1234"
-    path = "/api"
     username = 'user'
     password = 'pass'
-
+    host = "host.domain.tld"
+    path = "/api"
+    port = "1234"
     remote = mock() do
       expects(:call).with('login', username, password)
     end
@@ -78,8 +77,10 @@ describe Cobbler do
       XMLRPC::Client = mock() do
         stubs(:new).returns(remote)
       end
-
-      @data = {
+    end
+    
+    let(:data) do
+      {
         'profile' => 'centos-x86_64',
         'power_type' => 'ssh',
         'power_user' => 'root',
@@ -146,7 +147,7 @@ describe Cobbler do
     end
 
     it "item_from_hash should modify item with cobblerized data" do
-      cobblerized_data = Astute::Provision::Cobsh.new(@data.merge({'what' => 'system', 'name' => 'name'})).cobblerized
+      cobblerized_data = Astute::Provision::Cobsh.new(data.merge({'what' => 'system', 'name' => 'name'})).cobblerized
       cobbler = Astute::Provision::Cobbler.new
       cobbler.stubs(:get_item_id).with('system', 'name').returns('itemid')
       cobblerized_data.each do |opt, value|
@@ -160,11 +161,11 @@ describe Cobbler do
                                       'remotetoken'
                                       )
       end
-      cobbler.item_from_hash('system', 'name', @data, :item_preremove => true)
+      cobbler.item_from_hash('system', 'name', data, :item_preremove => true)
     end
 
     it "item_from_hash should modify 'system' interfaces with cobblerized['interfaces']" do
-      cobblerized_data = Astute::Provision::Cobsh.new(@data.merge({'what' => 'system', 'name' => 'name'})).cobblerized
+      cobblerized_data = Astute::Provision::Cobsh.new(data.merge({'what' => 'system', 'name' => 'name'})).cobblerized
       cobbler = Astute::Provision::Cobbler.new
       cobbler.stubs(:get_item_id).with('system', 'name').returns('itemid')
       cobbler.remote.expects(:call).with(
@@ -173,7 +174,7 @@ describe Cobbler do
                                     'modify_interface',
                                     cobblerized_data['interfaces'],
                                     'remotetoken')
-      cobbler.item_from_hash('system', 'name', @data, :item_preremove => true)
+      cobbler.item_from_hash('system', 'name', data, :item_preremove => true)
     end
 
   end

--- a/spec/unit/orchestrator_spec.rb
+++ b/spec/unit/orchestrator_spec.rb
@@ -301,22 +301,6 @@ describe Astute::Orchestrator do
         @orchestrator.stubs(:check_reboot_nodes).returns([])
         @orchestrator.provision(@reporter, data['engine'], data['nodes'])
       end
-      
-      it "should not provision nodes that ready for deploy" do
-        nodes = deep_copy data['nodes']
-        nodes << {'uid' => '2', 'status' => 'ready'}
-        nodes << {'uid' => '3', 'status' => 'provisioned'}
-        
-        engine = mock
-        engine.stubs(:sync)
-        @orchestrator.stubs(:create_engine).returns(engine)
-        @orchestrator.stubs(:reboot_nodes).returns([])
-        @orchestrator.stubs(:check_reboot_nodes).returns([])
-        
-        @orchestrator.expects(:add_nodes_to_cobbler).with(engine, data['nodes'])
-        
-        @orchestrator.provision(@reporter, data['engine'], nodes)
-      end
 
       before(:each) { Astute::Provision::Cobbler.any_instance.stubs(:power_reboot).returns(333) }
 

--- a/spec/unit/orchestrator_spec.rb
+++ b/spec/unit/orchestrator_spec.rb
@@ -454,7 +454,7 @@ describe Astute::Orchestrator do
 
         expect do
           @orchestrator.check_redhat_credentials(@reporter, data['task_uuid'], credentials)
-        end.to raise_error(/Invalid username or password/)
+        end.to raise_error(StopIteration)
       end
 
       it 'should not raise errors' do
@@ -469,7 +469,7 @@ describe Astute::Orchestrator do
 
         expect do
           @orchestrator.check_redhat_licenses(@reporter, data['task_uuid'], credentials)
-        end.to raise_error(/Could not find any valid Red Hat OpenStack subscriptions/)
+        end.to raise_error(StopIteration)
       end
 
       it 'should not raise errors ' do


### PR DESCRIPTION
- refactoring (rename 'fast_provision' to 'provision', 'provision' to 'watch_provision_progress' and more)
- fix bug with ignoring node status for provision operation (+ test);
- small test refactoring.
