### PR TITLE
Watch provision refactoring

### DIFF
--- a/bin/astute
+++ b/bin/astute
@@ -25,6 +25,10 @@ require 'astute'
 require 'astute/version'
 require 'astute/cli/enviroment'
 
+SUCCESS = 0
+FAIL = 1
+ERROR_CODE_COMMAND_USAGE = 64
+
 class ConsoleReporter
   def report(msg)
     puts msg.inspect
@@ -37,11 +41,12 @@ def report_and_exit(exception, verbose)
     puts "Hint: use astute with --verbose or check log (#{Astute::LOG_PATH}) for more details"
   end
   Astute.logger.error exception.format_backtrace
-  exit Astute::FAIL
+  exit FAIL
 end
 
-def analize_deploy(status)
-  status.has_value?('error') ? Astute::FAIL : Astute::SUCCESS
+def exit_code(status)
+  status.each { |node| return FAIL if node['status'] == 'error' }
+  SUCCESS
 end
 
 opts = {}
@@ -70,7 +75,6 @@ optparse.parse!(ARGV)
 
 if opts[:filename].nil?
   puts optparse
-  ERROR_CODE_COMMAND_USAGE = 64
   exit ERROR_CODE_COMMAND_USAGE
 end
 
@@ -98,7 +102,7 @@ def console_provision(orchestrator, reporter, environment)
   puts "restarting nodes..."
   sleep 5
   puts "start watching progress"
-  orchestrator.watch_provision_progress(reporter, environment['task_uuid'], environment['nodes'])
+  exit_code orchestrator.watch_provision_progress(reporter, environment['task_uuid'], environment['nodes'])
 end
 
 begin

--- a/lib/astute.rb
+++ b/lib/astute.rb
@@ -44,8 +44,6 @@ module Astute
   LogParser.autoload :ParseProvisionLogs, 'astute/logparser/provision'
   LogParser.autoload :Patterns, 'astute/logparser/parser_patterns'
 
-  SUCCESS = 0
-  FAIL = 1
   LOG_PATH = '/var/log/astute.log'
 
   def self.logger

--- a/lib/astute/cli/enviroment.rb
+++ b/lib/astute/cli/enviroment.rb
@@ -20,9 +20,9 @@ require 'astute/cli/yaml_validator'
 
 module Astute
   module Cli
-    
+
     class Enviroment
-      
+
       POWER_INFO_KEYS       = ['power_type', 'power_user', 'power_pass', 'netboot_enabled']
       ID_KEYS               = ['id', 'uid']
       COMMON_NODE_KEYS      = ['name_servers', 'profile']
@@ -32,28 +32,25 @@ module Astute
       NETWORK_KEYS          = ['ip', 'mac', 'fqdn']
       PROVISIONING_NET_KEYS = ['power_address']
       PROVISION_OPERATIONS  = [:provision]
-      
-      CIDR_REGEXP = '^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|
-                    2[0-4][0-9]|25[0-5])(\/(\d|[1-2]\d|3[0-2]))$'
-      
+
       def initialize(file, operation)
         @config = YAML.load_file(file)
         validate_enviroment(operation)
         to_full_config(operation)
       end
-      
+
       def [](key)
         @config[key]
       end
-  
+
       private
-      
+
       def to_full_config(operation)
         @config['nodes'].each do |node|
-        
+
           # Common section
           define_id_and_uid(node)
-        
+
           # Provision section
           if PROVISION_OPERATIONS.include? operation
             node['meta'] ||= {}
@@ -68,11 +65,11 @@ module Astute
           end
         end
       end
-      
+
       def validate_enviroment(operation)
         validator = YamlValidator.new(operation)
         errors = validator.validate(@config)
-      
+
         errors.each do |e|
           if e.message.include?("is undefined")
             Astute.logger.warn "[#{e.path}] #{e.message}"
@@ -81,13 +78,13 @@ module Astute
             $stderr.puts "[#{e.path}] #{e.message}"
           end
         end
-        
+
         if errors.select {|e| !e.message.include?("is undefined") }.size > 0
           raise Enviroment::ValidationError, "Environment validation failed"
         end
       end
-      
-      # Get data about discovered nodes using FuelWeb API 
+
+      # Get data about discovered nodes using FuelWeb API
       def find_node_api_data(node)
         @api_data ||= begin
           response = RestClient.get 'http://localhost:8000/api/nodes'
@@ -100,33 +97,33 @@ module Astute
         raise Enviroment::ValidationError, "Node #{node['name']} with mac address #{node['mac']}
                                             not find among discovered nodes"
       end
-      
+
       # Set uniq id and uid for node from Nailgun using FuelWeb API
       def define_id_and_uid(node)
         id = find_node_api_data(node)['id']
-        
+
         # This params set for node by Nailgun and should not be edit by user
         node.merge!(
           'id'  => id,
           'uid' => id
         )
       end
-      
-      # Set meta/disks section for node. This data used in provision to calculate the percentage 
+
+      # Set meta/disks section for node. This data used in provision to calculate the percentage
       # completion of the installation process.
       # Example result for node['meta']
       # "disks": [
       #   {
-      #     "model": "VBOX HARDDISK", 
-      #     "disk": "disk/by-path/pci-0000:00:0d.0-scsi-0:0:0:0", 
-      #     "name": "sda", 
+      #     "model": "VBOX HARDDISK",
+      #     "disk": "disk/by-path/pci-0000:00:0d.0-scsi-0:0:0:0",
+      #     "name": "sda",
       #     "size": 17179869184
       #   }...
       # ]
       def define_disks_section(node)
         node['meta']['disks'] = find_node_api_data(node)['meta']['disks']
       end
-      
+
       def define_parameters(node, config_group_name, keys, position=nil)
         position ||= node
         if @config[config_group_name]
@@ -135,30 +132,30 @@ module Astute
             position.reverse_merge!(key => config_group[key])
           end
         end
-        
+
         absent_keys = position.absent_keys(keys)
         if !absent_keys.empty?
-          raise Enviroment::ValidationError, "Please set #{config_group_name} block or 
+          raise Enviroment::ValidationError, "Please set #{config_group_name} block or
                 set params for #{node['name']} manually #{absent_keys.each {|k| p k}}"
         end
         @config.delete(config_group)
       end
-      
+
       # Add common params from common_node_settings to every node. Already certain parameters will not be changed.
       def define_node_settings(node)
         define_parameters(node, 'common_node_settings', COMMON_NODE_KEYS)
       end
-      
+
       # Add common params from common_power_info to every node. Already certain parameters will not be changed.
       def define_power_info(node)
         define_parameters(node, 'common_power_info', POWER_INFO_KEYS)
       end
-      
+
       # Add common params from common_ks_meta to every node. Already certain parameters will not be changed.
       def define_ks_meta(node)
         define_parameters(node, 'common_ks_meta', KS_META_KEYS, node['ks_meta'])
       end
-      
+
       # Add duplicates network params to node: ip, mac, fqdn
       def define_network_ids(node)
         network_eth = node['interfaces'].find {|eth| eth['use_for_provision'] } rescue nil
@@ -168,10 +165,10 @@ module Astute
             node['mac'] = network_eth['mac_address']
             api_node = find_node_api_data(node)
             api_provision_eth = api_node['meta']['interfaces'].find { |n| n['mac'].to_s.upcase == network_eth['mac_address'].to_s.upcase }
-            network_eth['ip_address'] = api_provision_eth['ip'] 
+            network_eth['ip_address'] = api_provision_eth['ip']
             network_eth['netmask'] = api_provision_eth['netmask']
           end
-          
+
           node.reverse_merge!(
             'ip'            => network_eth['ip_address'],
             'mac'           => network_eth['mac_address'],
@@ -179,20 +176,20 @@ module Astute
           )
           network_eth.delete('use_for_provision')
         end
-        
+
         absent_keys = node.absent_keys(NETWORK_KEYS)
         if !absent_keys.empty?
-          raise Enviroment::ValidationError, "Please set 'use_for_provision' parameter 
+          raise Enviroment::ValidationError, "Please set 'use_for_provision' parameter
                 for #{node['name']} or set manually #{absent_keys.each {|k| p k}}"
         end
       end
-      
+
        # Add duplicates network params to node: power_address
       def define_power_address(node)
-        node['power_address'] = node['ip'] or raise Enviroment::ValidationError, "Please 
+        node['power_address'] = node['ip'] or raise Enviroment::ValidationError, "Please
                                 set 'power_address' parameter for #{node['name']}"
       end
-    
+
       # Extend blocks interfaces and interfaces_extra to old formats:
       # interfaces:
       #   eth0:
@@ -207,26 +204,26 @@ module Astute
       #     peerdns: 'no'
       def define_interfaces_and_interfaces_extra(node)
         return if [node['interfaces'], node['extra_interfaces']].all? {|i| i.is_a?(Hash)}
-      
+
         formated_interfaces = {}
         interfaces_extra_interfaces = {}
         node['interfaces'].each do |eth|
           formated_interfaces[eth['name']] = eth
           formated_interfaces[eth['name']].delete('name')
           interfaces_extra_interfaces[eth['name']] = {
-            'onboot'  => eth['onboot'], 
+            'onboot'  => eth['onboot'],
             'peerdns' => eth['onboot']
           }
         end
         node['interfaces'] = formated_interfaces
-        node['extra_interfaces'] = interfaces_extra_interfaces  
+        node['extra_interfaces'] = interfaces_extra_interfaces
       end
-      
+
       # Add duplicate param 'fqdn' to node if it is not specified
       def define_fqdn(node)
         node['fqdn'] ||= find_node_api_data(node)['meta']['system']['fqdn']
       end
-      
+
       # Add meta/interfaces section for node:
       # meta:
       #   interfaces:
@@ -236,10 +233,10 @@ module Astute
       #     mac: 08:00:27:C2:06:DE
       #     max_speed: 100
       #     current_speed: 100
-      def define_meta_interfaces(node)   
+      def define_meta_interfaces(node)
         node['meta']['interfaces'] = find_node_api_data(node)['meta']['interfaces']
       end
-      
+
       # Add network_data section for node:
       # network_data:
       #   - dev: eth1
@@ -253,9 +250,9 @@ module Astute
       #     - storage
       def define_network_data(node)
         return if node['network_data'].is_a?(Array) && !node['network_data'].empty?
-        
+
         node['network_data'] = []
-        
+
         # If define_interfaces_and_interfaces_extra was call or format of config is full
         if node['interfaces'].is_a?(Hash)
           node['interfaces'].each do |key, value|
@@ -277,21 +274,21 @@ module Astute
           end
         end
       end
-  
-      # Generate 'ks_spaces' param from 'ks_disks' param in section 'ks_meta' 
-      # Example input for 'ks_disks' param: 
+
+      # Generate 'ks_spaces' param from 'ks_disks' param in section 'ks_meta'
+      # Example input for 'ks_disks' param:
       # [{
-      #   "type"=>"disk", 
+      #   "type"=>"disk",
       #   "id"=>"disk/by-path/pci-0000:00:0d.0-scsi-0:0:0:0",
-      #   "size"=>16384, 
+      #   "size"=>16384,
       #   "volumes"=>[
       #     {
-      #       "type"=>"boot", 
+      #       "type"=>"boot",
       #       "size"=>300
-      #     }, 
+      #     },
       #     {
-      #       "type"=>"pv", 
-      #       "size"=>16174, 
+      #       "type"=>"pv",
+      #       "size"=>16174,
       #       "vg"=>"os"
       #     }
       #   ]
@@ -302,24 +299,19 @@ module Astute
           node['ks_meta'].delete('ks_disks')
           return
         end
-    
+
         if node['ks_meta']['ks_disks'].blank?
-          raise Enviroment::ValidationError, "Please set 'ks_disks' or 'ks_spaces' parameter 
+          raise Enviroment::ValidationError, "Please set 'ks_disks' or 'ks_spaces' parameter
                 in section ks_meta for #{node['name']}"
         end
-    
+
         node['ks_meta']['ks_spaces'] = '"' + node['ks_meta']['ks_disks'].to_json.gsub("\"", "\\\"") + '"'
         node['ks_meta'].delete('ks_disks')
       end
-      
-      def is_cidr_notation?(value)
-        cidr = Regexp.new(CIDR_REGEXP)
-        !cidr.match(value).nil?
-      end
-      
+
     end # class end
-    
+
     class Enviroment::ValidationError < StandardError; end
-    
+
   end # module Cli
 end

--- a/lib/astute/orchestrator.rb
+++ b/lib/astute/orchestrator.rb
@@ -79,10 +79,10 @@ module Astute
     def watch_provision_progress(reporter, task_id, nodes)
       raise "Nodes to provision are not provided!" if nodes.empty?
 
-      provisionLogParser = @log_parsing ? LogParser::ParseProvisionLogs.new : LogParser::NoParsing.new
+      provision_log_parser = @log_parsing ? LogParser::ParseProvisionLogs.new : LogParser::NoParsing.new
       proxy_reporter = ProxyReporter::DeploymentProxyReporter.new(reporter)
 
-      prepare_logs_for_parsing(provisionLogParser, nodes)
+      prepare_logs_for_parsing(provision_log_parser, nodes)
 
       nodes_not_booted = nodes.map{ |n| n['uid'] }
       begin
@@ -99,7 +99,7 @@ module Astute
                 end
 
                 Astute.logger.debug("Nodes list length is not equal to target nodes list length: #{nodes.length} != #{target_uids.length}")
-                report_about_progress(proxy_reporter, provisionLogParser, target_uids, nodes)
+                report_about_progress(proxy_reporter, provision_log_parser, target_uids, nodes)
               end
             end
           end
@@ -207,11 +207,11 @@ module Astute
       reporter.report(status)
     end
 
-    def prepare_logs_for_parsing(provisionLogParser, nodes)
+    def prepare_logs_for_parsing(provision_log_parser, nodes)
       sleep_not_greater_than(10) do # Wait while nodes going to reboot
         Astute.logger.info "Starting OS provisioning for nodes: #{nodes.map{ |n| n['uid'] }.join(',')}"
         begin
-          provisionLogParser.prepare(nodes)
+          provision_log_parser.prepare(nodes)
         rescue => e
           Astute.logger.warn "Some error occurred when prepare LogParser: #{e.message}, trace: #{e.format_backtrace}"
         end
@@ -300,9 +300,9 @@ module Astute
       failed_nodes
     end
 
-    def report_about_progress(reporter, provisionLogParser, target_uids, nodes)
+    def report_about_progress(reporter, provision_log_parser, target_uids, nodes)
       begin
-        nodes_progress = provisionLogParser.progress_calculate(nodes.map{ |n| n['uid'] }, nodes)
+        nodes_progress = provision_log_parser.progress_calculate(nodes.map{ |n| n['uid'] }, nodes)
         nodes_progress.each do |n|
           if target_uids.include?(n['uid'])
             n['progress'] = 100

--- a/lib/astute/orchestrator.rb
+++ b/lib/astute/orchestrator.rb
@@ -38,7 +38,7 @@ module Astute
       context = Context.new(task_id, proxy_reporter, log_parser)
       deploy_engine_instance = @deploy_engine.new(context)
       Astute.logger.info "Using #{deploy_engine_instance.class} for deployment."
-      
+
       deploy_engine_instance.deploy(deployment_info)
       context.status
     end
@@ -79,40 +79,27 @@ module Astute
     def watch_provision_progress(reporter, task_id, nodes)
       raise "Nodes to provision are not provided!" if nodes.empty?
 
-      nodes_uids = nodes.map { |n| n['uid'] }
-
       provisionLogParser = @log_parsing ? LogParser::ParseProvisionLogs.new : LogParser::NoParsing.new
       proxy_reporter = ProxyReporter::DeploymentProxyReporter.new(reporter)
-      sleep_not_greater_than(10) do # Wait while nodes going to reboot
-        Astute.logger.info "Starting OS provisioning for nodes: #{nodes_uids.join(',')}"
-        begin
-          provisionLogParser.prepare(nodes)
-        rescue => e
-          Astute.logger.warn "Some error occurred when prepare LogParser: #{e.message}, trace: #{e.format_backtrace}"
-        end
-      end
-      nodes_not_booted = nodes_uids.clone
+
+      prepare_logs_for_parsing(provisionLogParser, nodes)
+
+      nodes_not_booted = nodes.map{ |n| n['uid'] }
       begin
         Timeout.timeout(Astute.config.PROVISIONING_TIMEOUT) do  # Timeout for booting target OS
           catch :done do
             while true
               sleep_not_greater_than(5) do
-                types = node_type(proxy_reporter, task_id, nodes, 2)
-                types.each { |t| Astute.logger.debug("Got node types: uid=#{t['uid']} type=#{t['node_type']}") }
-
-                Astute.logger.debug("Not target nodes will be rejected")
-                target_uids = types.reject{|n| n['node_type'] != 'target'}.map{|n| n['uid']}
-                nodes_not_booted -= types.map { |n| n['uid'] }
-                Astute.logger.debug "Not provisioned: #{nodes_not_booted.join(',')}, got target OSes: #{target_uids.join(',')}"
+                nodes_types = node_type(proxy_reporter, task_id, nodes, 2)
+                target_uids, nodes_not_booted = analize_node_types(nodes_types, nodes_not_booted)
 
                 if nodes.length == target_uids.length
                   Astute.logger.info "All nodes #{target_uids.join(',')} are provisioned."
                   throw :done
-                else
-                  Astute.logger.debug("Nodes list length is not equal to target nodes list length: #{nodes.length} != #{target_uids.length}")
                 end
 
-                report_about_progress(proxy_reporter, provisionLogParser, nodes_uids, target_uids, nodes)
+                Astute.logger.debug("Nodes list length is not equal to target nodes list length: #{nodes.length} != #{target_uids.length}")
+                report_about_progress(proxy_reporter, provisionLogParser, target_uids, nodes)
               end
             end
           end
@@ -126,15 +113,15 @@ module Astute
                                                   'error_msg' => msg,
                                                   'progress' => 100,
                                                   'error_type' => 'provision'} }
-        proxy_reporter.report({'status' => 'error', 'error' => msg, 'nodes' => error_nodes})
-        return FAIL
+        proxy_reporter.report('status' => 'error', 'error' => msg, 'nodes' => error_nodes)
+        error_nodes
       end
 
       nodes_progress = nodes.map do |n|
         {'uid' => n['uid'], 'progress' => 100, 'status' => 'provisioned'}
       end
-      proxy_reporter.report({'nodes' => nodes_progress})
-      return SUCCESS
+      proxy_reporter.report('nodes' => nodes_progress)
+      nodes_progress
     end
 
     def remove_nodes(reporter, task_id, nodes)
@@ -220,6 +207,27 @@ module Astute
       reporter.report(status)
     end
 
+    def prepare_logs_for_parsing(provisionLogParser, nodes)
+      sleep_not_greater_than(10) do # Wait while nodes going to reboot
+        Astute.logger.info "Starting OS provisioning for nodes: #{nodes.map{ |n| n['uid'] }.join(',')}"
+        begin
+          provisionLogParser.prepare(nodes)
+        rescue => e
+          Astute.logger.warn "Some error occurred when prepare LogParser: #{e.message}, trace: #{e.format_backtrace}"
+        end
+      end
+    end
+
+    def analize_node_types(types, nodes_not_booted)
+      types.each { |t| Astute.logger.debug("Got node types: uid=#{t['uid']} type=#{t['node_type']}") }
+      target_uids = types.reject{ |n| n['node_type'] != 'target' }.map{ |n| n['uid'] }
+      Astute.logger.debug("Not target nodes will be rejected")
+
+      nodes_not_booted -= types.map { |n| n['uid'] }
+      Astute.logger.debug "Not provisioned: #{nodes_not_booted.join(',')}, got target OSes: #{target_uids.join(',')}"
+      return target_uids, nodes_not_booted
+    end
+
     def sleep_not_greater_than(sleep_time, &block)
       time = Time.now.to_f
       block.call
@@ -229,7 +237,7 @@ module Astute
 
     def create_engine(engine_attrs, reporter)
       raise "Settings for Cobbler must be set" if engine_attrs.blank?
-      
+
       begin
         Astute.logger.info("Trying to instantiate cobbler engine: #{engine_attrs.inspect}")
         Astute::Provision::Cobbler.new(engine_attrs)
@@ -256,7 +264,7 @@ module Astute
         end
       end # end iteration
     end
-        
+
     def reboot_nodes(engine, nodes)
       nodes.inject({}) do |reboot_events, node|
         Astute.logger.debug("Trying to reboot node: #{node['name']}")
@@ -292,9 +300,9 @@ module Astute
       failed_nodes
     end
 
-    def report_about_progress(reporter, provisionLogParser, nodes_uids, target_uids, nodes)
+    def report_about_progress(reporter, provisionLogParser, target_uids, nodes)
       begin
-        nodes_progress = provisionLogParser.progress_calculate(nodes_uids, nodes)
+        nodes_progress = provisionLogParser.progress_calculate(nodes.map{ |n| n['uid'] }, nodes)
         nodes_progress.each do |n|
           if target_uids.include?(n['uid'])
             n['progress'] = 100


### PR DESCRIPTION
- refactoring watch_provision_progress orchestrator method;
- move SUCCESS and FAIL constants to CLI;
- remove trailing spaces;
- remove unused methods and constants.
